### PR TITLE
Bugfix: escaped_sortable_position_column for raw SQL queries

### DIFF
--- a/lib/activerecord/sortable/acts_as_sortable.rb
+++ b/lib/activerecord/sortable/acts_as_sortable.rb
@@ -16,15 +16,8 @@ module ActiveRecord
           }
           block.call(options) if block_given?
 
-          cattr_accessor :sortable_relation, instance_reader: false, instance_writer: false
-          cattr_accessor :sortable_append, instance_reader: true, instance_writer: false
-          cattr_accessor :sortable_position_column, instance_reader: true, instance_writer: false
-          cattr_accessor :escaped_sortable_position_column, instance_reader: true, instance_writer: false
-
-          self.sortable_relation = options[:relation]
-          self.sortable_append = options[:append]
-          self.sortable_position_column = options[:position_column]
-          self.escaped_sortable_position_column = ActiveRecord::Base.connection.quote_column_name(options[:position_column])
+          sortable_relation_create_accessors
+          sortable_relation_provide_accessor_values(options)
 
           scope "ordered_by_#{sortable_position_column}_asc".to_sym, -> { order(arel_table[sortable_position_column].asc) }
 
@@ -32,6 +25,22 @@ module ActiveRecord
           after_destroy :sortable_shift_on_destroy
 
           include ActiveRecord::Sortable::ActsAsSortable::InstanceMethods
+        end
+
+        private
+
+        def sortable_relation_create_accessors
+          cattr_accessor :sortable_relation, instance_reader: false, instance_writer: false
+          cattr_accessor :sortable_append, instance_reader: true, instance_writer: false
+          cattr_accessor :sortable_position_column, instance_reader: true, instance_writer: false
+          cattr_accessor :escaped_sortable_position_column, instance_reader: true, instance_writer: false
+        end
+
+        def sortable_relation_provide_accessor_values(options)
+          self.sortable_relation = options[:relation]
+          self.sortable_append = options[:append]
+          self.sortable_position_column = options[:position_column]
+          self.escaped_sortable_position_column = ActiveRecord::Base.connection.quote_column_name(options[:position_column])
         end
       end
     end

--- a/lib/activerecord/sortable/acts_as_sortable.rb
+++ b/lib/activerecord/sortable/acts_as_sortable.rb
@@ -19,10 +19,12 @@ module ActiveRecord
           cattr_accessor :sortable_relation, instance_reader: false, instance_writer: false
           cattr_accessor :sortable_append, instance_reader: true, instance_writer: false
           cattr_accessor :sortable_position_column, instance_reader: true, instance_writer: false
+          cattr_accessor :escaped_sortable_position_column, instance_reader: true, instance_writer: false
 
           self.sortable_relation = options[:relation]
           self.sortable_append = options[:append]
           self.sortable_position_column = options[:position_column]
+          self.escaped_sortable_position_column = ActiveRecord::Base.connection.quote_column_name(options[:position_column])
 
           scope "ordered_by_#{sortable_position_column}_asc".to_sym, -> { order(arel_table[sortable_position_column].asc) }
 

--- a/lib/activerecord/sortable/acts_as_sortable/instance_methods.rb
+++ b/lib/activerecord/sortable/acts_as_sortable/instance_methods.rb
@@ -71,7 +71,9 @@ module ActiveRecord
         end
 
         def sortable_shift_on_destroy
-          sortable_relation.where(["#{escaped_sortable_position_column} > ?", send(sortable_position_column)]).update_all sortable_updates_with_timestamps("#{escaped_sortable_position_column} = #{escaped_sortable_position_column} - 1")
+          position_threshold = send(sortable_position_column)
+          position_update = sortable_updates_with_timestamps("#{escaped_sortable_position_column} = #{escaped_sortable_position_column} - 1")
+          sortable_relation.where(["#{escaped_sortable_position_column} > ?", position_threshold]).update_all position_update
           true
         end
       end

--- a/lib/activerecord/sortable/acts_as_sortable/instance_methods.rb
+++ b/lib/activerecord/sortable/acts_as_sortable/instance_methods.rb
@@ -20,14 +20,14 @@ module ActiveRecord
 
         def sortable_relation_shift_left(new_position)
           sortable_relation
-            .where(["#{sortable_position_column} > ? AND #{sortable_position_column} <= ?", send(sortable_position_column), new_position])
-            .update_all sortable_updates_with_timestamps("#{sortable_position_column} = #{sortable_position_column} - 1")
+            .where(["#{escaped_sortable_position_column} > ? AND #{escaped_sortable_position_column} <= ?", send(sortable_position_column), new_position])
+            .update_all sortable_updates_with_timestamps("#{escaped_sortable_position_column} = #{escaped_sortable_position_column} - 1")
         end
 
         def sortable_relation_shift_right(new_position)
           sortable_relation
-            .where(["#{sortable_position_column} >= ? AND #{sortable_position_column} < ?", new_position, send(sortable_position_column)])
-            .update_all sortable_updates_with_timestamps("#{sortable_position_column} = #{sortable_position_column} + 1")
+            .where(["#{escaped_sortable_position_column} >= ? AND #{escaped_sortable_position_column} < ?", new_position, send(sortable_position_column)])
+            .update_all sortable_updates_with_timestamps("#{escaped_sortable_position_column} = #{escaped_sortable_position_column} + 1")
         end
 
         def sortable_relation
@@ -54,7 +54,7 @@ module ActiveRecord
         end
 
         def sortable_prepend_instance
-          sortable_relation.update_all sortable_updates_with_timestamps("#{sortable_position_column} = #{sortable_position_column} + 1")
+          sortable_relation.update_all sortable_updates_with_timestamps("#{escaped_sortable_position_column} = #{escaped_sortable_position_column} + 1")
           send("#{sortable_position_column}=".to_sym, 0)
         end
 
@@ -71,7 +71,7 @@ module ActiveRecord
         end
 
         def sortable_shift_on_destroy
-          sortable_relation.where(["#{sortable_position_column} > ?", send(sortable_position_column)]).update_all sortable_updates_with_timestamps("#{sortable_position_column} = #{sortable_position_column} - 1")
+          sortable_relation.where(["#{escaped_sortable_position_column} > ?", send(sortable_position_column)]).update_all sortable_updates_with_timestamps("#{escaped_sortable_position_column} = #{escaped_sortable_position_column} - 1")
           true
         end
       end

--- a/spec/dummy-3.2/app/models/order_thing.rb
+++ b/spec/dummy-3.2/app/models/order_thing.rb
@@ -1,0 +1,5 @@
+class OrderThing < ActiveRecord::Base
+  acts_as_sortable do |config|
+    config[:position_column] = :order
+  end
+end

--- a/spec/dummy-3.2/db/migrate/20150408101403_create_order_things.rb
+++ b/spec/dummy-3.2/db/migrate/20150408101403_create_order_things.rb
@@ -1,0 +1,11 @@
+class CreateOrderThings < ActiveRecord::Migration
+  def change
+    create_table :order_things do |t|
+      t.integer :order, :null => false
+
+      t.timestamps null: false
+    end
+
+    add_index :order_things, [:order]
+  end
+end

--- a/spec/dummy-3.2/db/schema.rb
+++ b/spec/dummy-3.2/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140721161122) do
+ActiveRecord::Schema.define(:version => 20150408101403) do
 
   create_table "children", :force => true do |t|
     t.string   "name",       :null => false
@@ -30,6 +30,14 @@ ActiveRecord::Schema.define(:version => 20140721161122) do
   end
 
   add_index "items", ["position"], :name => "index_items_on_position"
+
+  create_table "order_things", :force => true do |t|
+    t.integer  "order",      :null => false
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  add_index "order_things", ["order"], :name => "index_order_things_on_order"
 
   create_table "other_things", :force => true do |t|
     t.integer  "place",      :null => false

--- a/spec/dummy-4.0/app/models/order_thing.rb
+++ b/spec/dummy-4.0/app/models/order_thing.rb
@@ -1,0 +1,5 @@
+class OrderThing < ActiveRecord::Base
+  acts_as_sortable do |config|
+    config[:position_column] = :order
+  end
+end

--- a/spec/dummy-4.0/db/migrate/20150408101403_create_order_things.rb
+++ b/spec/dummy-4.0/db/migrate/20150408101403_create_order_things.rb
@@ -1,0 +1,11 @@
+class CreateOrderThings < ActiveRecord::Migration
+  def change
+    create_table :order_things do |t|
+      t.integer :order, :null => false
+
+      t.timestamps null: false
+    end
+
+    add_index :order_things, [:order]
+  end
+end

--- a/spec/dummy-4.0/db/schema.rb
+++ b/spec/dummy-4.0/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140721161122) do
+ActiveRecord::Schema.define(version: 20150408101403) do
 
   create_table "children", force: true do |t|
     t.string   "name",       null: false
@@ -30,6 +30,14 @@ ActiveRecord::Schema.define(version: 20140721161122) do
   end
 
   add_index "items", ["position"], name: "index_items_on_position"
+
+  create_table "order_things", force: true do |t|
+    t.integer  "order",      null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "order_things", ["order"], name: "index_order_things_on_order"
 
   create_table "other_things", force: true do |t|
     t.integer  "place",      null: false

--- a/spec/dummy-4.1/app/models/order_thing.rb
+++ b/spec/dummy-4.1/app/models/order_thing.rb
@@ -1,0 +1,5 @@
+class OrderThing < ActiveRecord::Base
+  acts_as_sortable do |config|
+    config[:position_column] = :order
+  end
+end

--- a/spec/dummy-4.1/db/migrate/20150408101403_create_order_things.rb
+++ b/spec/dummy-4.1/db/migrate/20150408101403_create_order_things.rb
@@ -1,0 +1,11 @@
+class CreateOrderThings < ActiveRecord::Migration
+  def change
+    create_table :order_things do |t|
+      t.integer :order, :null => false
+
+      t.timestamps null: false
+    end
+
+    add_index :order_things, [:order]
+  end
+end

--- a/spec/dummy-4.1/db/schema.rb
+++ b/spec/dummy-4.1/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140721161122) do
+ActiveRecord::Schema.define(version: 20150408101403) do
 
   create_table "children", force: true do |t|
     t.string   "name",       null: false
@@ -30,6 +30,14 @@ ActiveRecord::Schema.define(version: 20140721161122) do
   end
 
   add_index "items", ["position"], name: "index_items_on_position"
+
+  create_table "order_things", force: true do |t|
+    t.integer  "order",      null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "order_things", ["order"], name: "index_order_things_on_order"
 
   create_table "other_things", force: true do |t|
     t.integer  "place",      null: false

--- a/spec/dummy-4.2/app/models/order_thing.rb
+++ b/spec/dummy-4.2/app/models/order_thing.rb
@@ -1,0 +1,5 @@
+class OrderThing < ActiveRecord::Base
+  acts_as_sortable do |config|
+    config[:position_column] = :order
+  end
+end

--- a/spec/dummy-4.2/db/migrate/20150408101403_create_order_things.rb
+++ b/spec/dummy-4.2/db/migrate/20150408101403_create_order_things.rb
@@ -1,0 +1,11 @@
+class CreateOrderThings < ActiveRecord::Migration
+  def change
+    create_table :order_things do |t|
+      t.integer :order, :null => false
+
+      t.timestamps null: false
+    end
+
+    add_index :order_things, [:order]
+  end
+end

--- a/spec/dummy-4.2/db/schema.rb
+++ b/spec/dummy-4.2/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140721161122) do
+ActiveRecord::Schema.define(version: 20150408101403) do
 
   create_table "children", force: :cascade do |t|
     t.string   "name",       null: false
@@ -30,6 +30,14 @@ ActiveRecord::Schema.define(version: 20140721161122) do
   end
 
   add_index "items", ["position"], name: "index_items_on_position"
+
+  create_table "order_things", force: :cascade do |t|
+    t.integer  "order",      null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "order_things", ["order"], name: "index_order_things_on_order"
 
   create_table "other_things", force: :cascade do |t|
     t.integer  "place",      null: false

--- a/spec/order_thing_spec.rb
+++ b/spec/order_thing_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+# test for model with position column named `orded` (which can cause problems with raw SQL queries)
+describe OrderThing do
+  it_behaves_like 'activerecord-sortable', position_column: :order
+end


### PR DESCRIPTION
Added `escaped_sortable_position_column` attribute, which is used for raw SQL queries. It uses `ActiveRecord::Base.connection.quote_column_name` which is a must if the column is called `order`.